### PR TITLE
chore(deps): automerge pinDigest and lock file maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,13 +8,16 @@
   "schedule": ["after 1am and before 5am"],
   "labels": ["dependencies"],
   "rangeStrategy": "update-lockfile",
+  "lockFileMaintenance": {
+    "automerge": true
+  },
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
       "addLabels": ["actions"]
     },
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "pinDigest", "digest"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
Follow-up to #304. The initial Renovate config left two update types as manual merges; this makes them hands-off, consistent with the rest of the automerge policy.

## Why
PR #306 (`pin dependencies`) reported `🚦 Automerge: Disabled by config`. That update is the **`pinDigest`** type — first-time pinning of GitHub Actions from a tag to a commit SHA — which wasn't in the automerge `matchUpdateTypes` list (we only had `minor`, `patch`, `pin`, `digest`). Renovate's automerge is off by default, so unmatched types stay manual.

## Changes
- **Add `pinDigest`** to the automerged update types. Since `config:best-practices` deliberately pins Actions to digests (`helpers:pinGitHubActionDigests`), automerging the initial pin is the consistent choice. (Ongoing `digest` SHA bumps were already automerged.)
- **Automerge weekly lock file maintenance** (`lockFileMaintenance.automerge: true`) — the `Gemfile.lock` refresh from `:maintainLockFilesWeekly` previously opened a PR that waited for a manual merge.

`test` + `lint` branch protection still gates every merge, so nothing lands red.

Validated with `renovate-config-validator`.

> [!NOTE]
> This does not retroactively arm the already-open #306 — merge that one by hand. Future pinDigest/lock-maintenance PRs automerge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)