### PR TITLE
chore(deps): drop renovate schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,6 @@
     ":dependencyDashboard",
     ":timezone(Europe/Berlin)"
   ],
-  "schedule": ["after 1am and before 5am"],
   "labels": ["dependencies"],
   "rangeStrategy": "update-lockfile",
   "lockFileMaintenance": {


### PR DESCRIPTION
Drops the custom Renovate `schedule` so updates open on Renovateʼs next run instead of waiting for a window that the hosted app never hits.

## Why
The config had `"schedule": ["after 1am and before 5am"]` (Europe/Berlin = 23:00–03:00 UTC). On the Mend-hosted free tier, Renovate runs are driven mainly by webhooks plus infrequent background scans, and none were landing inside that 4-hour overnight window — so every queued update sat under **Awaiting Schedule** indefinitely (nothing opened for two days on cristiano).

## Why removing it is safe
Automerge is enabled for all low-risk update types, so PRs open **and** merge themselves once `Test` + `Lint` pass — time-of-day batching no longer buys anything. The overnight window was a Dependabot-era habit. `:timezone(Europe/Berlin)` is kept (used by weekly lock file maintenance).

Trade-off: PRs/merges may land at any hour. For CI-gated repos thatʼs harmless.

Validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)