### PR TITLE
chore(deps): group all non-major renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:best-practices",
     ":dependencyDashboard",
-    ":timezone(Europe/Berlin)"
+    ":timezone(Europe/Berlin)",
+    "group:allNonMajor"
   ],
   "labels": ["dependencies"],
   "rangeStrategy": "update-lockfile",


### PR DESCRIPTION
Groups all non-major dependency updates into a single PR via the `group:allNonMajor` preset.

## Why
The config produced one PR per dependency (the `config:best-practices` default). This adds `group:allNonMajor`, which collapses all **minor + patch** updates into a single branch/PR ("Update all non-major dependencies").

## Behavior after this
- **Minor/patch** updates → one combined PR that **automerges** once `Test` + `Lint` pass.
- **Major** updates (e.g. a new major of rubocop-rspec, or `ruby` v4) → still **separate** PRs you review individually.
- Trade-off: a grouped PR is all-or-nothing — if one package in the batch fails CI, the whole group waits until itʼs resolved (acceptable for dev tooling).

Validated with `renovate-config-validator`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)